### PR TITLE
Add entrypoint require file

### DIFF
--- a/lib/manageiq-password.rb
+++ b/lib/manageiq-password.rb
@@ -1,0 +1,1 @@
+require "manageiq/password"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,7 @@ if ENV['CI']
   SimpleCov.start
 end
 
-require "manageiq/password"
+require "manageiq-password"
 
 Dir[File.expand_path(File.join(__dir__, 'support/**/*.rb'))].each { |f| require f }
 


### PR DESCRIPTION
It is customary to a add a require entrypoint that matches the gem name, so that using this in a Gemfile will work.