### PR TITLE
Move PasswordMixin from ManageIQ with specs

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,9 @@
 #!/usr/bin/env ruby
 
 require "bundler/setup"
-require "manageiq/password"
+require "manageiq-password"
+
+ManageIQ::Password.key_root = File.expand_path("../spec/support", __dir__)
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.

--- a/lib/manageiq/password/password_mixin.rb
+++ b/lib/manageiq/password/password_mixin.rb
@@ -1,0 +1,55 @@
+module ManageIQ
+  class Password
+    module PasswordMixin
+      def self.included(other)
+        other.extend(ClassMethods)
+
+        other.class_attribute :encrypted_columns
+        other.encrypted_columns = []
+      end
+
+      module ClassMethods
+        def encrypt_column(column)
+          # Given a column of "password", create 4 instance methods:
+          #   password            : Get the password in plain text
+          #   password=           : Set the password in plain text
+          #   password_encrypted  : Get the password in cryptext
+          #   password_encrypted= : Set the password in cryptext
+
+          encrypted_columns << column.to_s
+          encrypted_columns << "#{column}_encrypted"
+
+          mod = generated_methods_for_password_mixin
+
+          mod.send(:define_method, column) do
+            val = send("#{column}_encrypted")
+            (val.nil? || val.empty?) ? val : MiqPassword.decrypt(val)
+          end
+
+          mod.send(:define_method, "#{column}=") do |val|
+            val = MiqPassword.try_encrypt(val) unless val.nil? || val.empty?
+            send("#{column}_encrypted=", val)
+          end
+
+          mod.send(:define_method, "#{column}_encrypted") do
+            read_attribute(column)
+          end
+
+          mod.send(:define_method, "#{column}_encrypted=") do |val|
+            write_attribute(column, val)
+          end
+        end
+
+        private
+
+        def generated_methods_for_password_mixin
+          @generated_methods_for_password_mixin ||= begin
+            mod = const_set(:GeneratedMethodsForPasswordMixin, Module.new)
+            include mod
+            mod
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/password_mixin_spec.rb
+++ b/spec/password_mixin_spec.rb
@@ -1,0 +1,87 @@
+require 'manageiq/password/password_mixin'
+
+RSpec.describe ManageIQ::Password::PasswordMixin do
+  before do
+    @old_key_root = ManageIQ::Password.key_root
+    ManageIQ::Password.key_root = File.join(__dir__, "support")
+  end
+
+  after do
+    ManageIQ::Password.key_root = @old_key_root
+  end
+
+  let(:fake_ar_base) do
+    Class.new do
+      attr_reader :attributes
+
+      def initialize
+        @attributes = {}
+      end
+
+      def read_attribute(attribute)
+        @attributes[attribute]
+      end
+
+      def write_attribute(attribute, value)
+        @attributes[attribute] = value
+      end
+
+      def self.define_column(column)
+        include Module.new do
+          define_method(column) do
+            read_attribute(column)
+          end
+
+          define_method("#{column}=") do |value|
+            write_attribute(column, value)
+          end
+        end
+      end
+
+      def self.class_attribute(attribute)
+        instance_eval(<<~DEF, __FILE__, __LINE__ + 1)
+          def self.#{attribute}
+            @#{attribute}
+          end
+
+          def self.#{attribute}=(value)
+            @#{attribute} = value
+          end
+        DEF
+      end
+    end
+  end
+
+  let(:fake_ar_model) do
+    Class.new(fake_ar_base) do
+      define_column :username
+      define_column :password
+
+      include ManageIQ::Password::PasswordMixin
+      encrypt_column :password
+    end
+  end
+
+  it ".encrypted_columns" do
+    expect(fake_ar_model.encrypted_columns).to match_array(%w[password password_encrypted])
+  end
+
+  it "underlying columns are stored encrypted" do
+    m = fake_ar_model.new
+
+    m.password = "pa$$w0rd"
+    expect(m.attributes[:password]).to be_encrypted
+  end
+
+  it "creates getters and setters" do
+    m = fake_ar_model.new
+
+    m.password = "pa$$w0rd"
+    expect(m.password).to eq("pa$$w0rd")
+    expect(m.password_encrypted).to be_encrypted
+
+    m.password_encrypted = ManageIQ::Password.encrypt("s00persecret")
+    expect(m.password).to eq("s00persecret")
+    expect(m.password_encrypted).to be_encrypted
+  end
+end


### PR DESCRIPTION
Only minor change to PasswordMixin was to change `val.blank?` to `val.nil? || val.empty?` to avoid having to bring in ActiveSupport, and removing `ActiveSupport::Concern` in favor of `self.included`

Since the mixin is meant to mix into ActiveRecord, but that's a lot of overhead for just testing, I decided to create a "fake" AR base that duck types the important methods.