### PR TITLE
The _encrypted methods are not columns and should not appear in the list

### DIFF
--- a/lib/manageiq/password/password_mixin.rb
+++ b/lib/manageiq/password/password_mixin.rb
@@ -17,7 +17,6 @@ module ManageIQ
           #   password_encrypted= : Set the password in cryptext
 
           encrypted_columns << column.to_s
-          encrypted_columns << "#{column}_encrypted"
 
           mod = generated_methods_for_password_mixin
 

--- a/spec/password_mixin_spec.rb
+++ b/spec/password_mixin_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe ManageIQ::Password::PasswordMixin do
   end
 
   it ".encrypted_columns" do
-    expect(fake_ar_model.encrypted_columns).to match_array(%w[password password_encrypted])
+    expect(fake_ar_model.encrypted_columns).to match_array(%w[password])
   end
 
   it "underlying columns are stored encrypted" do


### PR DESCRIPTION
In the example of "password":
Before: `.encrypted_columns => ["password", "password_encrypted"]`
After: `.encrypted_columns => ["password"]`