### PR TITLE
Require password_mixin when the gem is required

### DIFF
--- a/lib/manageiq/password.rb
+++ b/lib/manageiq/password.rb
@@ -1,4 +1,5 @@
 require "manageiq/password/version"
+require "manageiq/password/password_mixin"
 
 require 'openssl'
 require 'base64'

--- a/lib/manageiq/password/password_mixin.rb
+++ b/lib/manageiq/password/password_mixin.rb
@@ -1,5 +1,3 @@
-require "manageiq-password"
-
 module ManageIQ
   class Password
     module PasswordMixin

--- a/spec/password_mixin_spec.rb
+++ b/spec/password_mixin_spec.rb
@@ -1,5 +1,3 @@
-require 'manageiq/password/password_mixin'
-
 RSpec.describe ManageIQ::Password::PasswordMixin do
   let(:fake_ar_base) do
     Class.new do


### PR DESCRIPTION
This eliminates some ergnomic weirdness when requiring the gem.

@agrare Please review.