### PR TITLE
Drop deprecated methods

### DIFF
--- a/lib/manageiq/password.rb
+++ b/lib/manageiq/password.rb
@@ -90,14 +90,6 @@ module ManageIQ
       encrypted?(str) ? str : encrypt(str)
     end
 
-    # Deprecated. Only here for backward compatibility
-    def self.split(str)
-      return [nil, str] if str.nil? || str.empty?
-
-      enc = unwrap(str)
-      enc ? ["2", enc] : [nil, str]
-    end
-
     def self.key_root
       @@key_root ||= ENV["KEY_ROOT"]
     end
@@ -147,11 +139,6 @@ module ManageIQ
     # Deprecated. Only here for backward compatibility
     def self.keys
       legacy_keys.merge("v2" => key).delete_if { |_n, v| v.nil? }
-    end
-
-    # Deprecated. Only here for backward compatibility
-    def self.v2_key(key)
-      self.key = key
     end
 
     def self.generate_symmetric(filename = nil)

--- a/spec/password_spec.rb
+++ b/spec/password_spec.rb
@@ -63,9 +63,6 @@ RSpec.describe ManageIQ::Password do
       it(".recrypt") { expect(ManageIQ::Password.recrypt(enc)).to     eq(enc) }
       it("#recrypt") { expect(ManageIQ::Password.new.recrypt(enc)).to eq(enc) }
 
-      it(".split")           { expect(ManageIQ::Password.split(enc)).to  eq ["2", enc[4..-2]] }
-      it(".split decrypted") { expect(ManageIQ::Password.split(pass)).to eq [nil, pass] }
-
       %w[DB_PASSWORD MiqPassword ManageIQ::Password].each do |pass_method|
         enc_erb = "<%= #{pass_method}.decrypt(\"#{enc}\") %>"
 
@@ -77,8 +74,6 @@ RSpec.describe ManageIQ::Password do
 
           it(".recrypt") { expect(ManageIQ::Password.recrypt(enc_erb)).to     eq(enc) }
           it("#recrypt") { expect(ManageIQ::Password.new.recrypt(enc_erb)).to eq(enc) }
-
-          it(".split") { expect(ManageIQ::Password.split(enc_erb)).to eq ["2", enc[4..-2]] }
         end
       end
     end
@@ -137,11 +132,6 @@ RSpec.describe ManageIQ::Password do
       expect(ManageIQ::Password.try_encrypt(nil)).to     be_nil
       expect(ManageIQ::Password.try_encrypt("")).to      eq("v2:{}")
       expect(ManageIQ::Password.try_encrypt("v2:{}")).to eq("v2:{}")
-    end
-
-    it ".split" do
-      expect(ManageIQ::Password.split(nil)).to eq [nil, nil]
-      expect(ManageIQ::Password.split("")).to  eq [nil, ""]
     end
   end
 


### PR DESCRIPTION
This drops the rest of the deprecated methods that are left after #15 