### PR TITLE
[WIP] Detect incorrect decryption

### DIFF
--- a/lib/manageiq/password.rb
+++ b/lib/manageiq/password.rb
@@ -44,6 +44,7 @@ module ManageIQ
       return str if str.nil?
 
       decrypted_str   = decrypt(str, prior_key) if prior_key rescue nil
+      decrypted_str   = nil if decrypted_str && !decrypted_str.valid_encoding?
       decrypted_str ||= decrypt(str)
       encrypt(decrypted_str)
     end


### PR DESCRIPTION
It is possible that decrypting with the wrong key says that
it was decrypted, but in truth it just produced garbage.

this detects that the decryption produced a viable word

This is based upon https://github.com/ManageIQ/manageiq/pull/21239

If we want to encrypt and decrypt binary data, then this is not a good solution. I don't feel we would want to do this but possibly for public keys? (they tend to just be strings though)

Also note, that ruby's scoping is different from java/c. `decrypted_str` will get nil even if `prior_key` is nil and the block is never entered

/cc @jrafanie this is basically your code
I think @Fryguy does not want to go this route, but I wanted this PR in here none the less