### PR TITLE
protect v2_key

### DIFF
--- a/lib/manageiq/password.rb
+++ b/lib/manageiq/password.rb
@@ -140,7 +140,7 @@ module ManageIQ
     end
 
     def self.store_key_file(filename, key)
-      File.write(filename, key.to_h.to_yaml)
+      File.write(filename, key.to_h.to_yaml, :perm => 0440)
     end
 
     def self.load_key_file(filename)


### PR DESCRIPTION
chmod 440 (owner and group read, others nothing)

this will better protect our `v2_key`