### PR TITLE
[POC] [Discussion] Adds Ruby and Crystall CLI implementations

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,25 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 
+require "rake/clean"
+
+CLEAN.include "exe/manageiq-password.crystal"
+
 RSpec::Core::RakeTask.new(:spec)
+
+namespace :crystal do
+  file "lib/manageiq-password.cr"
+  directory "pkg"
+
+  file "pkg/manageiq-password.crystal" => %w[pkg lib/manageiq-password.cr] do |t|
+    sh "crystal build --release lib/manageiq-password.cr -o #{t.name}"
+  end
+
+  desc "Build the crystal cli"
+  task :build   => "pkg/manageiq-password.crystal"
+
+  desc "Re-build crystal cli"
+  task :rebuild => [:clean, :build]
+end
 
 task :default => :spec

--- a/exe/manageiq-password.rb
+++ b/exe/manageiq-password.rb
@@ -55,9 +55,9 @@ str ||= ARGF.read.strip
 
 case options[:mode]
 when "decrypt" then
-  puts ManageIQ::Password.decrypt(str)
+  print ManageIQ::Password.decrypt(str)
 when "encrypt"  then
-  puts ManageIQ::Password.encrypt(str)
+  print ManageIQ::Password.encrypt(str)
 else
 	warn "ERROR: Invalid mode: #{options[:mode]}"
 	exit 1

--- a/exe/manageiq-password.rb
+++ b/exe/manageiq-password.rb
@@ -1,0 +1,64 @@
+lib = File.expand_path("../../lib", __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
+require 'manageiq/password'
+require 'optparse'
+
+DEFAULT_KEY_FILE = File.join(Dir.pwd, "certs", "v2_key")
+
+options = {
+  :mode    => "decrypt",
+  :debug   => !!ENV["DEBUG"],
+  :keyfile => DEFAULT_KEY_FILE
+}
+
+OptionParser.new do |opts|
+  opts.banner = "Usage: #{File.basename($0)} [--encrypt|--decrypt] [--key KEYFILE] [string]"
+
+  opts.separator ""
+  opts.separator "Encrypts/Decrypts [string] (can be a value or passed from STDIN)"
+  opts.separator "using ManageIQ::Password."
+  opts.separator ""
+  opts.separator "Options:"
+
+  opts.on("-d",       "--decrypt", "Decrypt the value (default)") { options[:mode] = "decrypt" }
+  opts.on("-e",       "--encrypt", "Encrypt the value")           { options[:mode] = "encrypt" }
+
+  opts.on("-k",       "--key=KEY", "Path to the key file (default: #{DEFAULT_KEY_FILE})") do |path|
+    options[:keyfile] = path
+  end
+
+  opts.on(            "--debug", "Print debugging info") { options[:debug] = true  }
+
+  opts.on("-h", "-?", "--help", "Display help") do
+    puts opts
+    exit
+  end
+end.parse!
+
+ManageIQ::Password.key_root = File.dirname(options[:keyfile])
+
+puts <<-DEBUG if options[:debug]
+==============================================================================
+Mode:         #{options[:mode]}
+Key File:     #{options[:keyfile]}
+Algorithm:    #{ManageIQ::Password.key.algorithm}
+IV (Base64):  #{ManageIQ::Password.key.iv}
+IV (Hex):     #{ManageIQ::Password.key.raw_iv.to_s.unpack("*H*").first}
+Key (Base64): #{ManageIQ::Password.key.key}
+Key (Hex):    #{ManageIQ::Password.key.raw_key.to_s.unpack("*H*").first}
+==============================================================================
+DEBUG
+
+str   = ARGV.shift
+str ||= ARGF.read.strip
+
+case options[:mode]
+when "decrypt" then
+  puts ManageIQ::Password.decrypt(str)
+when "encrypt"  then
+  puts ManageIQ::Password.encrypt(str)
+else
+	warn "ERROR: Invalid mode: #{options[:mode]}"
+	exit 1
+end

--- a/lib/manageiq-password.cr
+++ b/lib/manageiq-password.cr
@@ -255,9 +255,9 @@ str ||= ARGF.gets_to_end.strip
 
 case options[:mode]
 when "decrypt" then
-  puts ManageIQ::Password.decrypt(str)
+  print ManageIQ::Password.decrypt(str)
 when "encrypt"  then
-  puts ManageIQ::Password.encrypt(str)
+  print ManageIQ::Password.encrypt(str)
 else
   STDERR.puts "ERROR: Invalid mode: #{options[:mode]}"
 	exit 1

--- a/lib/manageiq-password.cr
+++ b/lib/manageiq-password.cr
@@ -1,0 +1,264 @@
+require "base64"
+require "digest"
+require "openssl"
+require "random/secure"
+require "yaml"
+
+module ManageIQ
+  class Password
+    class PasswordError < RuntimeError; end
+
+    REGEXP = /v2:\{([^}]*)\}/
+    REGEXP_START_LINE = /^#{REGEXP}/
+    MASK = "********".freeze
+
+    property encStr : String?
+
+    class_setter key : Key?
+
+    def initialize(str = nil)
+      return unless str
+
+      @encStr = encrypt(str)
+    end
+
+    def encrypt(str, key = self.class.key)
+      return str if str.nil?
+
+      enc = key.encrypt64(str).delete("\n") unless str.empty?
+      self.class.wrap(enc)
+    end
+
+    def decrypt(str, key = self.class.key)
+      enc = self.class.unwrap(str)
+      return enc if enc.nil? || enc.empty?
+
+      begin
+        key.decrypt64(enc).encode("UTF-8")
+      rescue
+        raise PasswordError.new("cannot decrypt encrypted string")
+      end
+    end
+
+    def self.encrypt(*args)
+      new.encrypt(*args)
+    end
+
+    def self.decrypt(*args)
+      new.decrypt(*args)
+    end
+
+    def self.encrypted?(str)
+      return false if str.nil? || str.empty?
+      !!unwrap(str)
+    end
+
+    def self.key_root
+      @@key_root ||= ENV["KEY_ROOT"]
+    end
+
+    def self.key_root=(key_root)
+      @@key = nil
+      @@key_root = key_root
+    end
+
+    def self.key=(key)
+      @@key = key
+    end
+
+    def self.key
+      @@key ||= load_key_file("v2_key") || begin
+        key_file = File.expand_path("v2_key", key_root)
+        msg = <<-EOS
+  #{key_file} doesn't exist!
+  On an appliance, it should be generated on boot by evmserverd.
+
+  If you're a developer, you can copy the #{key_file}.dev to #{key_file}.
+
+  Caution, using the developer key will allow anyone with the public developer key to decrypt the two-way
+  passwords in your database.
+  EOS
+        STDERR.puts msg
+        Key.new(nil, nil, nil, true)
+      end
+    end
+
+    def self.generate_symmetric(filename = nil)
+      Key.new.tap { |key| store_key_file(filename, key) if filename }
+    end
+
+    protected def self.wrap(encrypted_str)
+      "v2:{#{encrypted_str}}"
+    end
+
+    protected def self.unwrap(str)
+      _unwrap(str) || _unwrap(extract_erb_encrypted_value(str))
+    end
+
+    private def self._unwrap(str)
+      return str if str.nil? || str.empty?
+
+      match = str.match(REGEXP_START_LINE)
+      match[1] if match
+    end
+
+    protected def self.store_key_file(filename, key)
+      File.write(filename, key.to_h.to_yaml, File::Permissions(0o440))
+    end
+
+    protected def self.load_key_file(filename)
+      return filename if filename.responds_to?(:decrypt64)
+
+      # if it is an absolute path, or relative to pwd, leave as is
+      # otherwise, look in key root for it
+      filename = File.expand_path(filename, key_root) unless File.exists?(filename)
+      return nil unless File.exists?(filename)
+
+      yaml_data = YAML.parse(File.read(filename))
+
+      algorithm = yaml_data[":algorithm"]?.to_s
+      key       = yaml_data[":key"]?.to_s
+      iv        = yaml_data[":iv"]?.to_s if yaml_data[":iv"]?
+
+      Key.new(algorithm, key, iv)
+    end
+
+    protected def self.extract_erb_encrypted_value(value)
+      return $1 if value =~ /\A<%= (?:MiqPassword|DB_PASSWORD|ManageIQ::Password)\.decrypt\(['"]([^'"]+)['"]\) %>\Z/
+    end
+
+    class Key
+      GENERATED_KEY_SIZE = 32
+
+      property  algorithm : String?
+      property  iv        : String?
+      property  key       : String?
+      property  raw_iv    : String
+      property  raw_key   : String
+      property? fake_key = true
+
+      def self.generate_key(password = nil, salt = nil)
+        password ||= Random::Secure.random_bytes(GENERATED_KEY_SIZE)
+        Base64.strict_encode(Digest::SHA256.digest("#{password}#{salt}")[0, GENERATED_KEY_SIZE])
+      end
+
+      def initialize(algorithm = nil, key = nil, iv = nil, fake_key = false)
+        @algorithm = algorithm || "aes-256-cbc"
+        @key       = key || generate_key
+        @raw_key   = Base64.decode_string(@key.as(String))
+        @iv        = iv
+        @raw_iv    = Base64.decode_string(iv || "")
+      end
+
+      def encrypt(str)
+        apply(:encrypt, str)
+      end
+
+      def encrypt64(str)
+        Base64.strict_encode(encrypt(str))
+      end
+
+      def decrypt(str)
+        apply(:decrypt, str)
+      end
+
+      def decrypt64(str)
+        decrypt(Base64.decode_string(str))
+      end
+
+      def to_s
+        @key
+      end
+
+      def to_h
+        {
+          :algorithm => @algorithm,
+          :key       => @key
+        }.tap do |h|
+          h[:iv] = @iv if @iv
+        end
+      end
+
+      private def generate_key
+        raise "key can only be generated for the aes-256-cbc algorithm" unless @algorithm == "aes-256-cbc"
+        self.class.generate_key
+      end
+
+      private def apply(mode, str)
+        c = OpenSSL::Cipher.new(@algorithm.to_s)
+        mode = :encrypt ? c.encrypt : c.decrypt
+
+        c.key = @raw_key
+        c.iv  = @raw_iv if @iv
+
+        io = IO::Memory.new
+        io.write(c.update(str))
+        io.write(c.final)
+        io.rewind
+
+        io.gets_to_end
+      end
+    end
+  end
+end
+
+require "option_parser"
+
+DEFAULT_KEY_FILE = File.join(Dir.current, "certs", "v2_key")
+
+options = {
+  :mode    => "decrypt",
+  :debug   => ENV["DEBUG"]? || false,
+  :keyfile => DEFAULT_KEY_FILE
+}
+
+OptionParser.parse do |opts|
+  opts.banner = "Usage: #{File.basename(PROGRAM_NAME)} [--encrypt|--decrypt] [--key KEYFILE] [string]"
+
+  opts.separator ""
+  opts.separator "Encrypts/Decrypts [string] (can be a value or passed from STDIN)"
+  opts.separator "using ManageIQ::Password."
+  opts.separator ""
+  opts.separator "Options:"
+
+  opts.on("-d",       "--decrypt", "Decrypt the value (default)") { options[:mode] = "decrypt" }
+  opts.on("-e",       "--encrypt", "Encrypt the value")           { options[:mode] = "encrypt" }
+
+  opts.on("-k KEY",   "--key=KEY", "Path to the key file (default: #{DEFAULT_KEY_FILE})") do |path|
+    options[:keyfile] = path
+  end
+
+  opts.on("--debug",               "Print debugging info") { options[:debug] = true  }
+
+  opts.on("-h",       "--help",    "Display help") do
+    puts opts
+    exit
+  end
+end
+
+ManageIQ::Password.key_root = File.dirname(options[:keyfile].as(String))
+
+puts <<-DEBUG if options[:debug]
+==============================================================================
+Mode:         #{options[:mode]}
+Key File:     #{options[:keyfile]}
+Algorithm:    #{ManageIQ::Password.key.algorithm}
+IV (Base64):  #{ManageIQ::Password.key.iv}
+IV (Hex):     #{ManageIQ::Password.key.raw_iv.to_s.to_slice.hexstring}
+Key (Base64): #{ManageIQ::Password.key.key}
+Key (Hex):    #{ManageIQ::Password.key.raw_key.to_slice.hexstring}
+==============================================================================
+DEBUG
+
+str   = ARGV.shift?
+str ||= ARGF.gets_to_end.strip
+
+case options[:mode]
+when "decrypt" then
+  puts ManageIQ::Password.decrypt(str)
+when "encrypt"  then
+  puts ManageIQ::Password.encrypt(str)
+else
+  STDERR.puts "ERROR: Invalid mode: #{options[:mode]}"
+	exit 1
+end

--- a/lib/manageiq/password.rb
+++ b/lib/manageiq/password.rb
@@ -161,6 +161,8 @@ module ManageIQ
     class Key
       GENERATED_KEY_SIZE = 32
 
+      attr_reader :algorithm, :iv, :key, :raw_iv, :raw_key
+
       def self.generate_key(password = nil, salt = nil)
         password ||= OpenSSL::Random.random_bytes(GENERATED_KEY_SIZE)
         Base64.strict_encode64(Digest::SHA256.digest("#{password}#{salt}")[0, GENERATED_KEY_SIZE])


### PR DESCRIPTION
I have no expectations of this being merged, but thought it was a good exercise in using crystal, and also a way of comparing the multiple possible implementations of this library.  There are pros and cons of each, which I will go through, but seeing as we have a working implementation I don't know there is value in merging.  However, I think this is worth providing as a discussion piece for future efforts where similar considerations are being made.

Rational
--------

So I have a few gripes with the implementation of #23 that introduced the `bash` CLI:

1. Does not share code with the library (risk if things change in the library, CLI doesn't reflect it, and tests don't catch)
2. Is not actually "`bash`-native" and does a lot of process spawning
3. A good chunk of the script has to be repeated in multiple places (not DRY)
4. Very hard to grok if not familiar with some of the oddities of `bash`/`shell` scripting

While #23 didn't provide much of a background rational, I actually can figure some of them out:

1. Bash scripting is clearly going to be faster than a Ruby implementation
2. This is a small enough where you can argue the speed trade offs might be worth it
3. Needed for future auth work in podified environments


and for the most part I am on board with the decision.  However, I have had an idea shared with me regarding `bash` and scripting that you should "...only use it for things around 20 lines, and after that consider using a higher level language".  And with this, I feel like we are starting down a path of potentially reaching for `bash` for everything without considering if it makes sense based on multiple factors to consider.


Factors to consider
-------------------

I think for this book of a PR, I think it is worth defining what our factors are for choosing a technology would be going forward.  These are what I am coming up with and will affect the future pros/cons section below, but I think this is a decent start:

1. Environment Requirements
2. Readability
3. Maintainability
4. Quirks
5. Performance

These are not meant to be in any particular order besides alphabetical, but we can decide on a "weight" for each at a later date.




Pros/Cons
---------

I am going through this section in order, and addressing each of the above factors for each pro/con section.  If they factor is not a "pro" for the most part, then it will be addressed in the "con" section, and vice versa.  It will be mentioned in both sections if there are considerations for each (aka: "it's complicated").

Also, this list is probably not exhaustive, but a start...

### Bash

A faster than a Ruby implementation, but much less readable and can easily become unwieldy to code in.

#### Pros

- Relatively ubiquitous and portable (Environment Requirements)
- Relatively fast and middle of the road (Performance)


#### Cons

- Bash/shell versions can be something to consider, and can cause weird failures if there is a mismatch in dev/prod (Environment Requirements)
- Least readable of the 3 (Readability)
- No way to unit test or share code with the original library (Maintainability)
- Bash is by far the strangest language to work with of the 3 (Quirks)
- "There's some weird newline nonsense games I had to play here..." [[ref](https://github.com/ManageIQ/manageiq-password/pull/23#issuecomment-912806647)] (Quirks)
- Performance is only maintained if you aren't doing a lot of pipes/subprocesses (Performance)




### Ruby

Slowest for sure, but able to share existing code and the slowness is not exponential.

#### Pros

- Ruby is basically expected to be available for most of our pods (Environment Requirements)
- Most readable of the 3, and terse (Readability)
- Shares/uses code with the main library (Maintainability)
- Few quirks and user friendly assuming you are familiar with Ruby (Quirks)

#### Cons

- Ruby environments are a pain to install, and not universally available (Environment Requirements)
- Requires access to the library at runtime to function (Environment Requirements)
- The slowest by far to start up (Performance)


### Crystal

Over all the fastest implementation, while still being pretty reasonable, but comes at a cost of building and not being able to share code.

#### Pros

- Self contained binary (Environment Requirements)
- Very ruby like and familiar (Readability)
- While doesn't share code, code is very similar to Ruby lib (Maintainability)
- Fastest implementation (Performance)

#### Cons

- Requires being built ahead of time for the build (Environment Requirements)
- No way to unit test or share code with the original library, unless we make it a c-ext for Ruby? (Maintainability)
- The type system can be cumbersome if used to Ruby (Quirks)


Performance numbers
-------------------

These are mostly extra info for those curious.  These were all run on my workstation.

A few things to note:

- These are the best of 5ish runs in quick succession.  Ruby and Bash had a bit more variation than Crystal.
- Bash gets slow quick if you pipe a lot
  - I understand `DEBUG=1` is not meant to be used all the time, just illustrating a performance consideration
- A few extra runs were done in Ruby to give context to the Ruby VM startup and script loading time

### Bash

#### `--help` (0m0.014s)

<details>
<summary><code>$ time exe/manageiq-password --help</code></summary>

```console
$ time exe/manageiq-password --help
Usage: manageiq-password [--encrypt|--decrypt] [--key KEYFILE]

Options:
-d, --decrypt   Decrypt the value on STDIN (default mode)
-e, --encrypt   Encrypt the value on STDIN
-k, --key       Path to the key file (default: /Users/nicklamuro/code/redhat/manageiq-password/certs/v2_key)

-h, --help, -?  Display help

real    0m0.014s
user    0m0.004s
sys     0m0.007s
```

</details>


#### `p4ssw0rd` (0m0.038s)

<details>
<summary><code>$ time (echo "p4ssw0rd" | exe/manageiq-password --key spec/support/v2_key --encrypt)</code></summary>

```console
$ time (echo "p4ssw0rd" | exe/manageiq-password --key spec/support/v2_key --encrypt)
v2:{xWV4T0GamSHhsXHuO/zUvA==}
real    0m0.038s
user    0m0.015s
sys     0m0.037s
```

</details>


#### `DEBUG=1` (0m0.071s)

<details>
<summary><code>$ time (echo "p4ssw0rd" | DEBUG=1 exe/manageiq-password --key spec/support/v2_key --encrypt)</code></summary>

```console
$ time (echo "p4ssw0rd" | DEBUG=1 exe/manageiq-password --key spec/support/v2_key --encrypt)
==============================================================================
Mode:         encrypt
Key File:     spec/support/v2_key
Algorithm:    aes-256-cbc
IV (Base64):
IV (Hex):
Key (Base64): 5ysYUd3Qrjj7DDplmEJHmnrFBEPS887JwOQv0jFYq2g=
Key (Hex):    e72b1851ddd0ae38fb0c3a659842479a7ac50443d2f3cec9c0e42fd23158ab68
==============================================================================
v2:{xWV4T0GamSHhsXHuO/zUvA==}
real    0m0.071s
user    0m0.027s
sys     0m0.065s
```

</details>




### Ruby

#### `--help` (0m0.157s)

<details>
<summary><code>$ time ruby exe/manageiq-password.rb --help</code></summary>

```console
$ time ruby exe/manageiq-password.rb --help
Usage: manageiq-password.rb [--encrypt|--decrypt] [--key KEYFILE] [string]

Encrypts/Decrypts [string] (can be a value or passed from STDIN)
using ManageIQ::Password.

Options:
    -d, --decrypt                    Decrypt the value (default)
    -e, --encrypt                    Encrypt the value
    -k, --key=KEY                    Path to the key file (default: /Users/nicklamuro/code/redhat/manageiq-password/certs/v2_key)
        --debug                      Print debugging info
    -h, -?, --help                   Display help

real    0m0.157s
user    0m0.114s
sys     0m0.038s
```

</details>


#### `p4ssw0rd` (0m0.156s)

<details>
<summary><code>$ time ruby exe/manageiq-password.rb --key spec/support/v2_key --encrypt p4ssw0rd</code></summary>

```console
$ time ruby exe/manageiq-password.rb --key spec/support/v2_key --encrypt p4ssw0rd
v2:{xWV4T0GamSHhsXHuO/zUvA==}

real    0m0.156s
user    0m0.113s
sys     0m0.039s
```

</details>

#### `p4ssw0rd` + `--disable-gems` (0m0.080s)

<details>
<summary><code>$ time ruby --disable-gems exe/manageiq-password.rb --key spec/support/v2_key --encrypt p4ssw0rd</code></summary>

```console
$ time ruby --disable-gems exe/manageiq-password.rb --key spec/support/v2_key --encrypt p4ssw0rd
v2:{xWV4T0GamSHhsXHuO/zUvA==}

real    0m0.080s
user    0m0.057s
sys     0m0.019s
```

</details>


#### `DEBUG=1` (0m0.159s)

<details>
<summary><code>$ time ruby exe/manageiq-password.rb --debug --key spec/support/v2_key --encrypt p4ssw0rd</code></summary>

```console
$ time ruby exe/manageiq-password.rb --debug --key spec/support/v2_key --encrypt p4ssw0rd
==============================================================================
Mode:         encrypt
Key File:     spec/support/v2_key
Algorithm:    aes-256-cbc
IV (Base64):
IV (Hex):
Key (Base64): 5ysYUd3Qrjj7DDplmEJHmnrFBEPS887JwOQv0jFYq2g=
Key (Hex):    e72b1851ddd0ae38fb0c3a659842479a7ac50443d2f3cec9c0e42fd23158ab68
==============================================================================
v2:{xWV4T0GamSHhsXHuO/zUvA==}

real    0m0.159s
user    0m0.114s
sys     0m0.039s
```

</details>


#### `ruby --disable-gems -e ""` (0m0.019s)

<details>
<summary><code>$ time ruby --disable-gems -e ""</code></summary>

```console
$ time ruby --disable-gems -e ""

real    0m0.019s
user    0m0.008s
sys     0m0.007s
```

</details>


### Crystal

#### `--help` (0m0.013s)

<details>
<summary><code>$ time pkg/manageiq-password.crystal --help</code></summary>

```console
$ time pkg/manageiq-password.crystal --help
Usage: manageiq-password.crystal [--encrypt|--decrypt] [--key KEYFILE] [string]

Encrypts/Decrypts [string] (can be a value or passed from STDIN)
using ManageIQ::Password.

Options:
    -d, --decrypt                    Decrypt the value (default)
    -e, --encrypt                    Encrypt the value
    -k KEY, --key=KEY                Path to the key file (default: /Users/nicklamuro/code/redhat/manageiq-password/certs/v2_key)
    --debug                          Print debugging info
    -h, --help                       Display help

real    0m0.013s
user    0m0.004s
sys     0m0.008s
```

</details>


#### `p4ssw0rd`(0m0.014s)

<details>
<summary><code>$ time pkg/manageiq-password.crystal --key spec/support/v2_key --encrypt p4ssw0rd</code></summary>

```console
$ time pkg/manageiq-password.crystal --key spec/support/v2_key --encrypt p4ssw0rd
v2:{xWV4T0GamSHhsXHuO/zUvA==}

real    0m0.014s
user    0m0.005s
sys     0m0.008s
```

</details>


#### `DEBUG=1` (0m0.014s)

<details>
<summary><code>$ time pkg/manageiq-password.crystal --debug --key spec/support/v2_key --encrypt p4ssw0rd</code></summary>

```console
$ time pkg/manageiq-password.crystal --debug --key spec/support/v2_key --encrypt p4ssw0rd
==============================================================================
Mode:         encrypt
Key File:     spec/support/v2_key
Algorithm:    aes-256-cbc
IV (Base64):
IV (Hex):
Key (Base64): 5ysYUd3Qrjj7DDplmEJHmnrFBEPS887JwOQv0jFYq2g=
Key (Hex):    e72b1851ddd0ae38fb0c3a659842479a7ac50443d2f3cec9c0e42fd23158ab68
==============================================================================
v2:{xWV4T0GamSHhsXHuO/zUvA==}

real    0m0.014s
user    0m0.005s
sys     0m0.008s
```

</details>