### PR TITLE
Raise an exception when decrypting plaintext

### DIFF
--- a/lib/manageiq/password.rb
+++ b/lib/manageiq/password.rb
@@ -30,6 +30,10 @@ module ManageIQ
     end
 
     def decrypt(str, key = self.class.key)
+      return str if str.nil? || str.empty?
+
+      raise PasswordError, "cannot decrypt plaintext string" unless self.class.encrypted?(str)
+
       enc = self.class.unwrap(str)
       return enc if enc.nil? || enc.empty?
 


### PR DESCRIPTION
Fixes #25

This should also fix the error in manageiq-automation_engine ([Travis](https://app.travis-ci.com/github/ManageIQ/manageiq-automation_engine/jobs/546790557#L2046-L2053)) that was expecting it to raise on plaintext.

```
  2) MiqAeEngine::MiqAeObject password raises exception for bogus passwords
     Failure/Error:
       expect do
         described_class.convert_value_based_on_datatype('gobbledygook', 'password')
       end.to raise_exception(ManageIQ::Password::PasswordError)

       expected ManageIQ::Password::PasswordError but nothing was raised
     # ./spec/miq_ae_object_spec.rb:324:in `block (3 levels) in <top (required)>'
```