### PR TITLE
Fix encrypted? and try_decrypt with erb strings

### DIFF
--- a/lib/manageiq/password.rb
+++ b/lib/manageiq/password.rb
@@ -30,9 +30,10 @@ module ManageIQ
     end
 
     def decrypt(str, key = self.class.key)
+      str = self.class.remove_erb(str)
       return str if str.nil? || str.empty?
 
-      raise PasswordError, "cannot decrypt plaintext string" unless self.class.encrypted?(str)
+      raise PasswordError, "cannot decrypt plaintext string" unless self.class.wrapped?(str)
 
       enc = self.class.unwrap(str)
       return enc if enc.nil? || enc.empty?
@@ -137,7 +138,7 @@ module ManageIQ
     def self.unwrap(str)
       return str if str.nil? || str.empty?
 
-      remove_erb(str).match(REGEXP_START_LINE)&.public_send(:[], 1)
+      str.match(REGEXP_START_LINE)&.public_send(:[], 1)
     end
 
     def self.wrapped?(str)

--- a/lib/manageiq/password.rb
+++ b/lib/manageiq/password.rb
@@ -86,6 +86,7 @@ module ManageIQ
     end
 
     def self.try_decrypt(str)
+      str = remove_erb(str)
       encrypted?(str) ? decrypt(str) : str
     end
 

--- a/spec/password_spec.rb
+++ b/spec/password_spec.rb
@@ -88,6 +88,8 @@ RSpec.describe ManageIQ::Password do
           it(".decrypt plaintext") { expect { ManageIQ::Password.decrypt(pass_erb) }.to     raise_error ManageIQ::Password::PasswordError }
           it("#decrypt plaintext") { expect { ManageIQ::Password.new.decrypt(pass_erb) }.to raise_error ManageIQ::Password::PasswordError }
 
+          it(".try_decrypt")           { expect(ManageIQ::Password.try_decrypt(enc_erb)).to  be_decrypted(pass) }
+          it(".try_decrypt plaintext") { expect(ManageIQ::Password.try_decrypt(pass_erb)).to eq(pass) }
 
           it(".encrypted?")           { expect(ManageIQ::Password.encrypted?(enc_erb)).to  be_truthy }
           it(".encrypted? plaintext") { expect(ManageIQ::Password.encrypted?(pass_erb)).to be_falsey }

--- a/spec/password_spec.rb
+++ b/spec/password_spec.rb
@@ -71,6 +71,9 @@ RSpec.describe ManageIQ::Password do
       it(".try_decrypt")           { expect(ManageIQ::Password.try_decrypt(enc)).to  be_decrypted(pass) }
       it(".try_decrypt plaintext") { expect(ManageIQ::Password.try_decrypt(pass)).to eq(pass) }
 
+      it(".encrypted?")           { expect(ManageIQ::Password.encrypted?(enc)).to  be_truthy }
+      it(".encrypted? plaintext") { expect(ManageIQ::Password.encrypted?(pass)).to be_falsey }
+
       it(".recrypt") { expect(ManageIQ::Password.recrypt(enc)).to     eq(enc) }
       it("#recrypt") { expect(ManageIQ::Password.new.recrypt(enc)).to eq(enc) }
 
@@ -85,7 +88,9 @@ RSpec.describe ManageIQ::Password do
           it(".decrypt plaintext") { expect { ManageIQ::Password.decrypt(pass_erb) }.to     raise_error ManageIQ::Password::PasswordError }
           it("#decrypt plaintext") { expect { ManageIQ::Password.new.decrypt(pass_erb) }.to raise_error ManageIQ::Password::PasswordError }
 
-          it(".try_decrypt") { expect(ManageIQ::Password.try_decrypt(enc_erb)).to be_decrypted(pass) }
+
+          it(".encrypted?")           { expect(ManageIQ::Password.encrypted?(enc_erb)).to  be_truthy }
+          it(".encrypted? plaintext") { expect(ManageIQ::Password.encrypted?(pass_erb)).to be_falsey }
 
           it(".recrypt") { expect(ManageIQ::Password.recrypt(enc_erb)).to     eq(enc) }
           it("#recrypt") { expect(ManageIQ::Password.new.recrypt(enc_erb)).to eq(enc) }


### PR DESCRIPTION
These 2 methods didn't have specs, and so didn't work consistently with and without erb strings.  While these cases are unlikely, this brings the methods into consistency.

Due to the way this code has been changed, I've also found ways to eliminate a lot of extra regex scans that would otherwise happen to non-erb strings, which is a lot cleaner/faster/GC friendly.

@agrare or @chessbyte Please review.