### PR TITLE
Change .to_s to use a regular attr_reader

### DIFF
--- a/lib/manageiq/password.rb
+++ b/lib/manageiq/password.rb
@@ -175,6 +175,9 @@ module ManageIQ
         Base64.strict_encode64(Digest::SHA256.digest("#{password}#{salt}")[0, GENERATED_KEY_SIZE])
       end
 
+      attr_reader :key
+      alias to_s key
+
       def initialize(algorithm = nil, key = nil, iv = nil)
         @algorithm = algorithm || "aes-256-cbc"
         @key       = key || generate_key
@@ -197,10 +200,6 @@ module ManageIQ
 
       def decrypt64(str)
         decrypt(Base64.decode64(str))
-      end
-
-      def to_s
-        @key
       end
 
       def to_h

--- a/spec/password_spec.rb
+++ b/spec/password_spec.rb
@@ -259,3 +259,13 @@ RSpec.describe ManageIQ::Password do
     expect(ManageIQ::Password.key).to eq new_key
   end
 end
+
+RSpec.describe ManageIQ::Password::Key do
+  it "#key" do
+    expect(ManageIQ::Password.key.key).to eq "5ysYUd3Qrjj7DDplmEJHmnrFBEPS887JwOQv0jFYq2g="
+  end
+
+  it ".to_s" do
+    expect(ManageIQ::Password.key.to_s).to eq "5ysYUd3Qrjj7DDplmEJHmnrFBEPS887JwOQv0jFYq2g="
+  end
+end


### PR DESCRIPTION
Before this change, it was not clear that the key was exposed. After this change a normal .key accessor works, and .to_s is just declared as an alias of that accessor.

@jrafanie Please review.  Technically this will require a minor version bump.