### PR TITLE
Add support for ruby 3.1's psych 4 default of safe_load

### DIFF
--- a/lib/manageiq/password.rb
+++ b/lib/manageiq/password.rb
@@ -157,7 +157,8 @@ module ManageIQ
       filename = File.expand_path(filename, key_root) unless File.exist?(filename)
       return nil unless File.exist?(filename)
 
-      Key.new(*YAML.load_file(filename).values_at(:algorithm, :key, :iv))
+      # Switch to YAML.safe_load_file when we drop ruby 2.7.  Psych 3.2.1 added it.
+      Key.new(*YAML.safe_load(File.read(filename), :permitted_classes => [Symbol, Time]).values_at(:algorithm, :key, :iv))
     end
 
     private_class_method def self.remove_erb(str)

--- a/spec/support/v2_key
+++ b/spec/support/v2_key
@@ -1,3 +1,4 @@
 ---
+:created: 2014-02-28 09:59:47 -0500
 :algorithm: aes-256-cbc
 :key: 5ysYUd3Qrjj7DDplmEJHmnrFBEPS887JwOQv0jFYq2g=


### PR DESCRIPTION
Technically, we could use safe_load_file but that was added in psych 3.2.1, see: https://github.com/ruby/psych/commit/0210e310d04cbc9b236ccdde6caaf79aab4eb794

It's easy enough to maintain 2.7 support by implementing it using File.read plus safe_load without making a dependency change.

We can switch when we drop ruby 2.7 as 3.0 defaults to psych 3.3.x+.

Add Time field to the test v2_key to verify it's broken with ruby 3.1 before this change and works after.

Part of https://github.com/ManageIQ/manageiq/issues/22696